### PR TITLE
feat(commands/down.ts): new option -d in down command to remove volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,19 +142,20 @@ OPTIONS
 
 _See code: [src/commands/up.ts](https://github.com/badassery/laravel-up/blob/v0.0.8/src/commands/up.ts)_
 
-## `lvl down [DIRECTORY]`
+## `lvl down [DIRECTORY] [OPTIONS,]`
 
 To Stop your local dev environment
 
 ```
 USAGE
-  $ lvl down [DIRECTORY]
+  $ lvl down [DIRECTORY] [OPTIONS,]
 
 ARGUMENTS
   DIRECTORY  Running Laravel Up directory you would like to stop
 
 OPTIONS
   -v, --verbose
+  -d, --destroy To remove dev environment docker volumes
 ```
 
 _See code: [src/commands/down.ts](https://github.com/badassery/laravel-up/blob/v0.0.8/src/commands/down.ts)_

--- a/src/commands/down.ts
+++ b/src/commands/down.ts
@@ -3,12 +3,22 @@ import { Command, flags } from "@oclif/command";
 import chalk from "chalk";
 import * as shelljs from "shelljs";
 import { testTargetDirectory, displayCommandHeader } from "../actions";
+import * as inquirer from "inquirer";
 
 export default class Down extends Command {
   static description = "describe the command here";
 
   static flags = {
-    verbose: flags.boolean({ char: "v", default: false })
+    verbose: flags.boolean({
+      char: "v",
+      default: false,
+      description: "To have descriptive log process"
+    }),
+    destroy: flags.boolean({
+      char: "d",
+      default: false,
+      description: "To destroy Laravel up dev environment docker volumes"
+    })
   };
 
   static args = [
@@ -21,7 +31,7 @@ export default class Down extends Command {
   async run() {
     const { args, flags } = this.parse(Down);
 
-    displayCommandHeader("Shutting down your project...");
+    displayCommandHeader("Shutting down your Laravel up dev environment...");
 
     const directory = args.directory
       ? args.directory
@@ -31,9 +41,40 @@ export default class Down extends Command {
       return false;
     }
 
-    shelljs.cd(directory);
-    shelljs.exec("docker-compose down", { silent: !flags.verbose });
+    let assuredDestroy = false;
+    if (flags.destroy) {
+      assuredDestroy = (await inquirer.prompt([
+        {
+          message: chalk.yellow(
+            "Are you sure you would like remove dev environment volumes?"
+          ),
+          name: "confirm",
+          type: "confirm"
+        }
+      ])).confirm;
+      console.log();
+    }
 
-    console.log(chalk.green("Your app is stopped"));
+    shelljs.cd(directory);
+    shelljs.exec(
+      ["docker-compose", "down", assuredDestroy ? "-v" : ""].join(" "),
+      { silent: !flags.verbose }
+    );
+
+    const extendedMessage = assuredDestroy
+      ? ` & ${chalk.bgRedBright(
+          chalk.black(" ✘ removed ")
+        )} dev environment volumes`
+      : ` ${chalk.bgGreen(
+          chalk.black(" without ")
+        )} removing dev environment volumes`;
+
+    console.log(
+      chalk.green(
+        `Your dev environment is stopped${
+          flags.destroy ? extendedMessage : ""
+        }.`
+      )
+    );
   }
 }


### PR DESCRIPTION
Added new option `-d` `--destroy` in `lvl down` command to destroy dev environment docker volumes.

re #8