### PR TITLE
feat(commands/new.ts): [#11] Fix lvl new command on Windows

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -58,10 +58,21 @@ export default class New extends Command {
 
     cli.ux.action.start("Creating your App!");
 
-    shelljs.exec(
-      `docker container run --rm --user $(id -u):$(id -g) -v $(pwd):/app composer create-project --prefer-dist laravel/laravel ${projectName}`,
-      { silent: !flags.verbose }
-    );
+    if (this.config.windows) {
+      // We need to interpolate this value in JS since we can't in cmd.exe
+      const currentDir = shelljs.pwd();
+
+      // Omit the --user argument on Windows. It is not necessary
+      shelljs.exec(
+        `docker container run --rm -v ${currentDir}:/app composer create-project --prefer-dist laravel/laravel ${projectName}`,
+        { silent: !flags.verbose }
+      );
+    } else {
+      shelljs.exec(
+        `docker container run --rm --user $(id -u):$(id -g) -v $(pwd):/app composer create-project --prefer-dist laravel/laravel ${projectName}`,
+        { silent: !flags.verbose }
+      );
+    }
 
     cli.ux.action.stop();
 


### PR DESCRIPTION
Fixes #11 

`--user` command was not necessary on Windows. Looks like `exec` uses `cmd.exe` by default though and not PowerShell. Something to keep in mind.